### PR TITLE
Remove no longer needed workaround

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- vs2022
 libhwy:
 - '1.2'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/libhwy-feedstoc
 
 Home: https://github.com/google/highway
 
-Package license: Apache-2.0
+Package license: Apache-2.0 OR BSD-3-Clause
 
 Summary: Efficient and performance-portable vector software
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,5 +13,5 @@ cmake                                           ^
     ..
 if errorlevel 1 exit 1
 
-ninja install -j1
+ninja install
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,14 +3,9 @@ ls -lah
 mkdir c_build
 cd c_build
 
-# glibc 2.12 (Current default at conda-forge)
-# doesn't define certain string macros without
-# this definition.
-# it has been removed in glibc 2.17
-# https://github.com/google/highway/pull/524#issuecomment-1025676250
-CXXFLAGS="-D__STDC_FORMAT_MACROS ${CXXFLAGS}"
 cmake                                \
     ${CMAKE_ARGS}                    \
+    -G "Ninja"                       \
     -DCMAKE_BUILD_TYPE=Release       \
     -DBUILD_TESTING=OFF              \
     -DBUILD_SHARED_LIBS=ON           \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,10 +1,4 @@
-c_compiler:    # [win]
-- vs2019       # [win]
-cxx_compiler:  # [win]
-- vs2019       # [win]
-
-
-# It seems that there is a build error with GCC 11 and 12
+# It seems that there is a build error with GCC 11, 12, 13, 14 and 15 on ppc64le
 # https://github.com/google/highway/issues/1570
 # https://github.com/google/highway/commit/213fd6a06b290c4ed9cf4d5a26fdfc32e8a47aa8
 # We are hitting an internal compiler error ....

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 07b3c1ba2c1096878a85a31a5b9b3757427af963b1141ca904db2f9f4afe0bc2
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('libhwy', max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ requirements:
     - {{ stdlib('c') }}
     - cmake
     - pkg-config            # [unix]
-    - make                  # [unix]
-    - ninja                 # [win]
+    - ninja
 
 test:
   commands:
@@ -38,9 +37,10 @@ test:
 
 about:
   home: https://github.com/google/highway
-  license: Apache-2.0
-  license_family: Apache
-  license_file: LICENSE
+  license: Apache-2.0 OR BSD-3-Clause
+  license_file:
+    - LICENSE
+    - LICENSE-BSD3
   summary: Efficient and performance-portable vector software
 
 extra:


### PR DESCRIPTION
Hello @conda-forge/libhwy,

I way looking for `highway` and missed the `libhwy` feedstock.
I have done another [recipe](https://github.com/conda-forge/staged-recipes/pull/31092) and figured out that some workaround you add in your recipe are no more needed.

This PR do the following:
- Remove glibc workaround
- Remove MSVC compiler constraints
- Use Ninja on all core
- Add BSD-3-Clause license

GCC 14 and 15 still crash on ppc64le.

If you want I can also replace the conda-build recipe by a rattler-build one.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
